### PR TITLE
Update clickbait sites and let EasyPrivacy take care of managing ad networks

### DIFF
--- a/clickbait.txt
+++ b/clickbait.txt
@@ -8,78 +8,15 @@
 ! Perion Networks, through its subsidiaries, appears to operate at least 41 domains
 ! Pesto Harel Shemesh (also known as Crunchmind) appears to operate 88 websites 
 
-! Ads
-! Taboola
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L2141
-! taboola
-||am-vid-events.taboola.com^
-||convsgmp.taboola.com^
-||la-sync.taboola.com^
-||nr-events.taboola.com^
-||opps.taboola.com^
-||sync.taboola.com^
-||taboola.com/?uid=
-||taboola.com/libtrc/
-||taboola.com/tb?
-||taboola.com^*/json?tim=
-||taboola.com^*/log/
-||taboola.com^*/notify-impression?$third-party
-||taboolasyndication.com/log/
-||taboolasyndication.com^*/log/
-||urc.taboolasyndication.com^
-||vidstat.taboola.com^
-||wf.taboola.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist.txt#L321
-@@||taboola.com/libtrc/impl.$script,domain=businessinsider.com|insider.com
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist_international.txt#L45
-@@||taboola.com/libtrc/$script,domain=bild.de|bz-berlin.de|computerbild.de|fitbook.de|jetzt.de|metal-hammer.de|musikexpress.de|noizz.de|rollingstone.de|stylebook.de|techbook.de|travelbook.de|welt.de|wieistmeineip.at|wieistmeineip.ch|wieistmeineip.de
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist_international.txt#L170
-@@||trc.taboola.com/inncoil/log/3/available$subdocument,domain=inn.co.il
+! Ad Networks
+! Taboola, Outbrain, Sokrati
+!#include EasyPrivacy
 
 ! New Addition(s) - need to verify
 ! ||cdn.taboola.com^$third-party
 
-! Outbrain
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1089
-||bluekai.com^$domain=disqus.com|widgets.outbrain.com
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1111
-||hpr.outbrain.com^$domain=focus.de
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1116
-||log.outbrain.com^$domain=autobild.de|focus.de|metal-hammer.de|musikexpress.de|rollingstone.de|widgets.outbrain.com
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1125
-||rlcdn.com^$domain=autobild.de|widgets.outbrain.com
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific_international.txt#L823
-||log.outbrain.com^$domain=focus.de
-||scorecardresearch.com^$domain=outbrain.com
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_general.txt#L3084
-/outbrainClientPixels.
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L60
-||amplify.outbrain.com^$third-party
-||amplifypixel.outbrain.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L974
-||hpr.outbrain.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1157
-||log.outbrain.com^
-||log.outbrainimg.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1218
-||mcdp-*.outbrain.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1355
-||outbrain.com/nanoWidget/externals/cookie/
-||outbrain.com/widgetOBUserSync/
-||outbrain.com^*/widgetStatistics.js
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1636
-||stas.outbrain.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1720
-||sync.outbrain.com^$third-party
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1771
-||tcheck.outbrainimg.com^
-! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L2004
-||videoevents.outbrain.com^
-
-! TODO: Sokrati
-
-! Sites who exist only for clickbait
-! Checked for cdn.taboola.com or amplify.outbrain.com or widgets.outbrain.com or linked from known clickbait sites
+! Sites which exist only for clickbait
+! Check for cdn.taboola.com or amplify.outbrain.com or widgets.outbrain.com or linked from known clickbait sites
 
 ! Perion Networks
 ! same Google Analytics ID UA-43750835-36/ UA-178993256-6 (new) or Taboola tracking pixel ID 1240533 or Yahoo tracking pixel ID 10122972 as magellantimes.com

--- a/clickbait.txt
+++ b/clickbait.txt
@@ -2,22 +2,148 @@
 ! Description: Isn't it annoying when news websites and search results are filled with random stuff you never wanted? This list hopefully makes some of that go away
 ! This list was inspired by https://github.com/DandelionSprout/adfilt/issues/272
 
+! References
+! https://www.morningbrew.com/marketing/stories/2021/09/08/brands-still-playing-ball-clickbait-ad-sites-advertisings-roach-will-survive-bomb
+! https://adalytics.io/blog/network-graph-analysis-to-identify-related-websites
+! Perion Networks, through its subsidiaries, appears to operate at least 41 domains
+! Pesto Harel Shemesh (also known as Crunchmind) appears to operate 88 websites 
+
 ! Ads
-taboola.com$all
-outbrain.com$all
-sokrati.com$all
+! Taboola
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L2141
+! taboola
+||am-vid-events.taboola.com^
+||convsgmp.taboola.com^
+||la-sync.taboola.com^
+||nr-events.taboola.com^
+||opps.taboola.com^
+||sync.taboola.com^
+||taboola.com/?uid=
+||taboola.com/libtrc/
+||taboola.com/tb?
+||taboola.com^*/json?tim=
+||taboola.com^*/log/
+||taboola.com^*/notify-impression?$third-party
+||taboolasyndication.com/log/
+||taboolasyndication.com^*/log/
+||urc.taboolasyndication.com^
+||vidstat.taboola.com^
+||wf.taboola.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist.txt#L321
+@@||taboola.com/libtrc/impl.$script,domain=businessinsider.com|insider.com
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist_international.txt#L45
+@@||taboola.com/libtrc/$script,domain=bild.de|bz-berlin.de|computerbild.de|fitbook.de|jetzt.de|metal-hammer.de|musikexpress.de|noizz.de|rollingstone.de|stylebook.de|techbook.de|travelbook.de|welt.de|wieistmeineip.at|wieistmeineip.ch|wieistmeineip.de
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_allowlist_international.txt#L170
+@@||trc.taboola.com/inncoil/log/3/available$subdocument,domain=inn.co.il
+
+! New Addition(s) - need to verify
+! ||cdn.taboola.com^$third-party
+
+! Outbrain
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1089
+||bluekai.com^$domain=disqus.com|widgets.outbrain.com
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1111
+||hpr.outbrain.com^$domain=focus.de
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1116
+||log.outbrain.com^$domain=autobild.de|focus.de|metal-hammer.de|musikexpress.de|rollingstone.de|widgets.outbrain.com
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L1125
+||rlcdn.com^$domain=autobild.de|widgets.outbrain.com
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific_international.txt#L823
+||log.outbrain.com^$domain=focus.de
+||scorecardresearch.com^$domain=outbrain.com
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_general.txt#L3084
+/outbrainClientPixels.
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L60
+||amplify.outbrain.com^$third-party
+||amplifypixel.outbrain.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L974
+||hpr.outbrain.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1157
+||log.outbrain.com^
+||log.outbrainimg.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1218
+||mcdp-*.outbrain.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1355
+||outbrain.com/nanoWidget/externals/cookie/
+||outbrain.com/widgetOBUserSync/
+||outbrain.com^*/widgetStatistics.js
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1636
+||stas.outbrain.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1720
+||sync.outbrain.com^$third-party
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L1771
+||tcheck.outbrainimg.com^
+! https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_thirdparty.txt#L2004
+||videoevents.outbrain.com^
+
+! TODO: Sokrati
 
 ! Sites who exist only for clickbait
-itsthevibe.com$document
-eliteherald.com$document
-magellantimes.com$document
-! https://github.com/DandelionSprout/adfilt/issues/272#issuecomment-917392781
-pawszilla.com$document
-zenherald.com$document
-historicalpost.com$document
+! Checked for cdn.taboola.com or amplify.outbrain.com or widgets.outbrain.com or linked from known clickbait sites
+
+! Perion Networks
+! same Google Analytics ID UA-43750835-36/ UA-178993256-6 (new) or Taboola tracking pixel ID 1240533 or Yahoo tracking pixel ID 10122972 as magellantimes.com
+! loads pubocean-tracker.js
+! https://lh6.googleusercontent.com/jnZD7P2C5u0lsP8o10-Z_qHHQk9ADy5A5o7FtrlFX8xWD7e4KZ09dXP-a2ii67IrqgLEIvU_xnjYhD8q8Y8pyHz6YXJb5OrbU0Kbbuio-EqTtRqdPbDQwoDKRJgoqYU-6FCgIyKB=s0
+absolutehistory.com$document
 affluenttimes.com$document
 atlanticmirror.com$document
+autoinquirer.com$document
+brillianttraveler.com$document
+eliteherald.com$document
+equitymirror.com$document
+guerillainsurance.com$document
+happinesstimes.com$document
+historicalgenius.com$document
+historicalpost.com$document
+inspiringpet.com$document
+luxandlush.com$document
+magellantimes.com$document
+moneycougar.com$document
+mowmag.com$document
+nextrefinance.com$document
+nightdaily.com$document
+opulentexpress.com$document
+pawszilla.com$document
+petsfanatic.com$document
+scribol.com$document
+totalpast.com$document
+unleashedfinance.com$document
+wealtheditor.com$document
+zenherald.com$document$document
 
+! NOT SURE ABOUT THIS
+! trivia.com
+! earth.com
+! trendscatchers.de
+
+! TODO: Pesto Harel Shemesh (also known as Crunchmind)
+
+! Other clickbait sites cross-linked
+! autooverload and bonvoyaged have the same designs
+autooverload.com$document
+bonvoyaged.com$document
+
+adventurecrunch.com$document
+centurylink.net$document
+definition.org$document
+elitereaders.com$document
+factinate.com$document
+gazillions.com$document
+heraldweekly.com$document
+inventgoddess.com$document
+itsthevibe.com$document$document
+postfun.com$document
+theclever.com$document
+therichest.com$document
+thetalko.com$document
+thethings.com$document
+upbeatnews.com$document
+worldlifestyle.com$document
+
+! NOT SURE ABOUT THIS
+! historydaily.org
+! maternityweek.com
 
 ! Copied over from https://raw.githubusercontent.com/cpeterso/clickbait-blocklist/master/clickbait-blocklist.txt
 adblade.com$all


### PR DESCRIPTION
### Reason for this pull request
Added more clickbait sites

### What changes have been made to this branch?
Clickbait.txt has been updated with references (so that others can read and contribute as well) and removed the complete blocking of the ad networks, as that might break websites.


- [ ] Does this pull request fix an issue? 
#### If so, list the issue(s) fixed below
Will finally fix https://github.com/DandelionSprout/adfilt/issues/272

### Checklist
- [ ] I have not modified any files in the Alternative list formats directory <!--these files are updated automatically; changes need to be made to antimalware.txt, or (in the case of issues with that format) update.py-->
- [ ] I have not modified duckduckgo-clean-up.txt <!--duckduckgo-clean-up.txt is auto-generated from duckduckgo-clean-up.template and the domains version of my antimalware list. Modify duckduckgo-clean-up.template to change its contents, or antimalware.txt to remove domains-->
- [ ] I have not modified totalentries.svg <!--that is auto-updated--> and porn_auto.txt <!--these domains are auto-generated by the computer-->

No