### PR TITLE
Remove redundant rule

### DIFF
--- a/anti-rickroll-list.txt
+++ b/anti-rickroll-list.txt
@@ -10,7 +10,6 @@
 !A rickroll website
 secretrickroll.com$all
 !Hide text containing the word rickroll - does not even work
-!##*:has-text(Get rickroll)
 !##*:has-text(rickroll)
 !Hide images/videos containing the word rickroll
 !##[src*=rickroll]:not(iframe)


### PR DESCRIPTION
!##*:has-text(rickroll) made it redundant


### Reason for this pull request
To Remove redundant rule. !##*:has-text(rickroll) made !##*:has-text(Get rickroll)
 redundant 


### What changes have been made to this branch?
Removed redundant rule. !##*:has-text(rickroll) made !##*:has-text(Get rickroll)
 redundant


- [ ] Does this pull request fix an issue? 
#### If so, list the issue(s) fixed below
NA

### Checklist
- [x] I have not modified any files in the Alternative list formats directory <!--these files are updated automatically; changes need to be made to antimalware.txt, or (in the case of issues with that format) update.py-->
- [x] I have not modified duckduckgo-clean-up.txt <!--duckduckgo-clean-up.txt is auto-generated from duckduckgo-clean-up.template and the domains version of my antimalware list. Modify duckduckgo-clean-up.template to change its contents, or antimalware.txt to remove domains-->
- [x] I have not modified totalentries.svg <!--that is auto-updated--> and porn_auto.txt <!--these domains are auto-generated by the computer-->
