### PR TITLE
Fixed extra space in bad filter

### DIFF
--- a/antimalware.txt
+++ b/antimalware.txt
@@ -6328,7 +6328,7 @@ ostrowlubelski.pl##^responseheader(location)
 ||146.70.192.174^$document
 ||149.88.27.212^$document
 ||154.223.16.34^$document
-||38.180.41.251 ^$document
+||38.180.41.251^$document
 ||203.160.86.91^$document
 ||srgsd1f.842b727ba4.ipv6.1433.eu.org^$all
 ||edcjn.57fe6f5d9d.ipv6.1433.eu.org^$all


### PR DESCRIPTION
### Reason for this pull request
There is a bad filter that had an invalid pattern, just removing the space.

### What changes have been made to this branch?
I removed a space in a filter pattern

- [x] Does this pull request fix an issue? 
#### If so, list the issue(s) fixed below
Invalid filter: Bad pattern

### Checklist
- [ x] I have not modified any files in the Alternative list formats directory <!--these files are updated automatically; changes need to be made to antimalware.txt, or (in the case of issues with that format) update.py-->
- [ x] I have not modified duckduckgo-clean-up.txt <!--duckduckgo-clean-up.txt is auto-generated from duckduckgo-clean-up.template and the domains version of my antimalware list. Modify duckduckgo-clean-up.template to change its contents, or antimalware.txt to remove domains-->
- [ x] I have not modified totalentries.svg <!--that is auto-updated--> and porn_auto.txt <!--these domains are auto-generated by the computer-->
